### PR TITLE
Fix 2-speed fans being reported as on-off (1-speed) devices

### DIFF
--- a/custom_components/switch_fan/fan.py
+++ b/custom_components/switch_fan/fan.py
@@ -77,8 +77,8 @@ class SwitchFan(FanEntity):
     ) -> None:
         """Initialize the fan entity."""
         features = FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
-        # If we have more than 2 entity then we can set multiple speeds
-        if len(entity_ids) > 2:
+        # If we have more than 1 entity then we can set multiple speeds
+        if len(entity_ids) > 1:
             features |= FanEntityFeature.SET_SPEED
         self.entity_ids = entity_ids
         self.entity_states = {}


### PR DESCRIPTION
The proper treshold for multiple speeds fan is strictly more than 1 switch, not 2; since a 2-speed fan (50%,100%) will have 2 switches.
I've tested and confirmed it behaves properly with a DIY-build device, which otherwise had the 2nd speed inaccessible.